### PR TITLE
add docs recursively to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include AUTHORS
 include ChangeLog
 include LICENSE
+recursive-include docs *


### PR DESCRIPTION
When packaging or installing from source, it's nice to provide the
documentation to end users if required.  This puts the documentation
into the sdist on pypi for packages to use directly rather than getting
them from github.
