### PR TITLE
Play nicely with installations that do not bundle urllib3

### DIFF
--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -16,7 +16,10 @@ from requests.adapters import HTTPAdapter
 from requests.cookies import MockRequest, MockResponse
 from requests.cookies import RequestsCookieJar
 from requests.cookies import merge_cookies, cookiejar_from_dict
-from requests.packages.urllib3.response import HTTPResponse
+try:
+    from requests.packages.urllib3.response import HTTPResponse
+except ImportError:
+    from urllib3.response import HTTPResponse
 import six
 
 from requests_mock import compat


### PR DESCRIPTION
Piggybacking off of this PR: [getsentry #12](https://github.com/getsentry/responses/pull/12)

If you try to use requests-mock in Ubuntu you get this error without this change:

     ImportError: No module named packages.urllib3.response