### PR TITLE
Add in the abilty to pass in a pre-setup Adapter to the Mocker class

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -41,7 +41,7 @@ class MockerCore(object):
                         'call_count'])
 
     def __init__(self, **kwargs):
-        self._adapter = adapter.Adapter()
+        self._adapter = kwargs.pop('adapter', adapter.Adapter())
         self._real_http = kwargs.pop('real_http', False)
         self._real_send = None
 
@@ -134,6 +134,8 @@ class Mocker(MockerCore):
             as this named keyword argument, rather than a positional argument.
         :param bool real_http: True to send the request to the real requested
             uri if there is not a mock installed for it. Defaults to False.
+        :param object adapter: Pass request_mock.Adapter that has had matchers
+            added. Defaults to creating a new Adapter object
         """
         self._kw = kwargs.pop('kw', None)
         super(Mocker, self).__init__(**kwargs)
@@ -156,7 +158,8 @@ class Mocker(MockerCore):
         """
         m = Mocker(
             kw=self._kw,
-            real_http=self._real_http
+            real_http=self._real_http,
+            adapter=self._adapter
         )
         return m
 


### PR DESCRIPTION
Ran into a case where I wanted to have the same mocking across multiple test suites and am decorating the test class. I did not want to have to repeat the same setup code across many tests

In a central location, like test utils module:
```
adapter = requests_mock.Adapter()
adapter.register_uri('GET', '/checks', status_code=200)
```

In the test class importing the adapter object and using like so
```
@requests_mock.Mocker(real_http=True, adapter=adapter)
```