### PR TITLE
Requests version is broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,10 +61,16 @@ Or as a decorator:
 
 For more information checkout the `docs`_.
 
-Reporting Bugs
-==============
+Contribute
+=========
 
+Reporting Bugs
+--------------
 Please report all bugs on `LaunchPad`_.
+
+Developers
+----------
+Fork the `repository`_ on GitHub to start making your changes to the master branch (or branch off of it).
 
 License
 =======
@@ -84,3 +90,4 @@ under the License.
 .. _requests: http://python-requests.org
 .. _docs: http://requests-mock.readthedocs.org
 .. _LaunchPad: https://bugs.launchpad.net/requests-mock
+.. _repository: https://github.com/openstack/requests-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=1.1
+requests>=2.6.0
 six


### PR DESCRIPTION
Unable to import the package when using old `requests` version. fixed to first version without the following exception
```
Traceback (most recent call last):
  File "./test.py", line 2, in <module>
    import requests_mock
  File "/home/eli/requests/.venv/local/lib/python2.7/site-packages/requests_mock/__init__.py", line 13, in <module>
    from requests_mock.adapter import Adapter, ANY
  File "/home/eli/requests/.venv/local/lib/python2.7/site-packages/requests_mock/adapter.py", line 15, in <module>
    from requests.adapters import BaseAdapter
  File "/home/eli/requests/requests/__init__.py", line 58, in <module>
    from . import utils
  File "/home/eli/requests/requests/utils.py", line 24, in <module>
    from . import __version__
  File "/home/eli/requests/requests/compat.py", line 42, in <module>
    from .packages.urllib3.packages.ordered_dict import OrderedDict
  File "/home/eli/requests/requests/packages/__init__.py", line 83, in load_module
    raise ImportError("No module named '%s'" % (name,))
ImportError: No module named 'requests.packages.urllib3'
```

PS: also add link to the repository, since I was unable to find it on pypi