### PR TITLE
Add __str__ representation to _RequestObjectProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ htmlcov
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
 
 # Complexity
 output/*.html

--- a/requests_mock/request.py
+++ b/requests_mock/request.py
@@ -152,3 +152,6 @@ class _RequestObjectProxy(object):
         the matcher is not available it will return None.
         """
         return self._matcher()
+
+    def __str__(self):
+        return "{0.method} {0.url}".format(self._request)

--- a/requests_mock/tests/test_request.py
+++ b/requests_mock/tests/test_request.py
@@ -117,3 +117,7 @@ class RequestTests(base.TestCase):
         self.assertEqual('host.example.com', req.netloc)
         self.assertEqual('host.example.com', req.hostname)
         self.assertEqual(443, req.port)
+
+    def test_to_string(self):
+        req = self.do_request(url='https://host.example.com/path')
+        self.assertEqual('GET https://host.example.com/path', str(req))


### PR DESCRIPTION
This PR changes `__str__` to `"GET http://example.com/path"`. It leaves `__repr__` unchanged.

You can now quickly do simple assertions like:
```python
self.assertIn("GET http://example.com/path", [str(r) for r in requests_mock.request_history])
```

It would be nice if `_RequestHistoryTracker` had functions to easily test for matched URLs, but simply adding legible `__str__` helps us get halfway.