### PR TITLE
Allow mocker to get an optional adapter argument

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -62,7 +62,7 @@ class MockerCore(object):
 
     def __init__(self, **kwargs):
         case_sensitive = kwargs.pop('case_sensitive', self.case_sensitive)
-        self._adapter = adapter.Adapter(case_sensitive=case_sensitive)
+        self._adapter = kwargs.pop('adapter') or adapter.Adapter(case_sensitive=case_sensitive)
 
         self._real_http = kwargs.pop('real_http', False)
         self._last_send = None


### PR DESCRIPTION
To better compose adapter with mocker session, allow the use of a preset Adapter() object.

typical use:

```python
def test_mock():
    cache = CacheFolder(os.path.expanduser("~/cached_responses"))
    adapter = cache.get_adapter()
    with requests_mock.Mocker(adapter=adapter) as m:
        x = requests.get("https://jsonplaceholder.typicode.com/posts/1")
    print(x.json())
```