### PR TITLE
Add testing for newer Python versions 3.5 and 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,12 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
 test_suite = requests_mock.tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py27,pypy,pep8
+envlist = py36,py35,py34,py27,pypy,pep8
 
 [testenv]
 setenv =


### PR DESCRIPTION
Include all supported Python versions as trove classifiers. Helps library users know, at a glance, if the library can be integrated with a project.

Remove Python 2.6 trove classifier, support was removed in 9bcf955af8dd62aa52c86e48a4868d2725353531

Also add trove classifier for PyPy as it is included in the tox test matrix.