### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ all_files = 1
 build-dir = doc/build
 source-dir = doc/source
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [extras]


### PR DESCRIPTION
For additional details, see:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125

http://pythonwheels.com/