### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ author-email = jamielennox@gmail.com
 summary = Mock out responses from the requests package
 description-file = README.rst
 license = Apache-2
+license-file = LICENSE
 home-page = https://requests-mock.readthedocs.org/
 classifier =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the [metadata] section in the setup.cfg file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file